### PR TITLE
add support request pointer and update status page

### DIFF
--- a/messagehub109.md
+++ b/messagehub109.md
@@ -17,7 +17,7 @@ lastupdated: "2017-08-18"
 # Reporting a problem to the {{site.data.keyword.messagehub}} team
 {: #report_problem}
 
-If you're experiencing a problem with {{site.data.keyword.messagehub}}, first check the [{{site.data.keyword.Bluemix_notm}} status page ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://status.ng.bluemix.net/){:new_window}. 
+If you're experiencing a problem with {{site.data.keyword.messagehub}}, first check the [{{site.data.keyword.Bluemix_notm}} status page ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://console.bluemix.net/status){:new_window}. 
 
 If you'd like help from the {{site.data.keyword.messagehub}} team, please gather as much of the following information as possible:
 {:shortdesc}
@@ -35,7 +35,7 @@ You can find this ID by looking at the "instance_id" field in the service's VCAP
 10. What impact is the problem having on your service?
 
 
-
+Provide the information gathered above to IBM in a support ticket by [submitting a support request](https://console.bluemix.net/docs/services/MessageHub/messagehub109.html#report_problem).
 
 
 


### PR DESCRIPTION
Fixes IBM-Bluemix-Docs/MessageHub#1
Updates the URL for the status page to use the new global console status page.